### PR TITLE
Stitcher: Add playout-limit support to interstitials 

### DIFF
--- a/packages/stitcher/src/interstitials.ts
+++ b/packages/stitcher/src/interstitials.ts
@@ -16,11 +16,14 @@ export function getStaticDateRanges(session: Session, isLive: boolean) {
       "CONTENT-MAY-VARY": "YES",
       "TIMELINE-OCCUPIES": "POINT",
       "TIMELINE-STYLE": getTimelineStyle(interstitial),
-      "PLAYOUT-LIMIT": interstitial.duration,
     };
 
     if (!isLive) {
       clientAttributes["RESUME-OFFSET"] = 0;
+    }
+
+    if (interstitial.duration) {
+      clientAttributes["PLAYOUT-LIMIT"] = interstitial.duration;
     }
 
     const cue: string[] = ["ONCE"];

--- a/packages/stitcher/src/interstitials.ts
+++ b/packages/stitcher/src/interstitials.ts
@@ -16,6 +16,7 @@ export function getStaticDateRanges(session: Session, isLive: boolean) {
       "CONTENT-MAY-VARY": "YES",
       "TIMELINE-OCCUPIES": "POINT",
       "TIMELINE-STYLE": getTimelineStyle(interstitial),
+      "PLAYOUT-LIMIT": interstitial.duration,
     };
 
     if (!isLive) {

--- a/packages/stitcher/src/routes/session.ts
+++ b/packages/stitcher/src/routes/session.ts
@@ -39,6 +39,7 @@ export const sessionRoutes = new Elysia()
           t.Array(
             t.Object({
               time: t.Union([t.Number(), t.String()]),
+              duration: t.Optional(t.Number()),
               assets: t.Optional(
                 t.Array(
                   t.Object({

--- a/packages/stitcher/src/session.ts
+++ b/packages/stitcher/src/session.ts
@@ -20,6 +20,7 @@ export interface Session {
 
 interface SessionInterstitial {
   time: number | string;
+  duration?: number;
   assets?: {
     uri: string;
     kind?: "ad" | "bumper";
@@ -85,14 +86,14 @@ function mapSessionInterstitials(
   interstitials: SessionInterstitial[],
 ) {
   return interstitials.map<Interstitial>((item) => {
-    const { time, assets, ...rest } = item;
+    const { time, duration, assets, ...rest } = item;
     const dateTime =
       typeof time === "string"
         ? DateTime.fromISO(time)
         : startTime.plus({ seconds: time });
-
     return {
       dateTime,
+      duration,
       assets: assets?.map((asset) => {
         const { uri, ...rest } = asset;
         return { url: resolveUri(uri), ...rest };

--- a/packages/stitcher/src/session.ts
+++ b/packages/stitcher/src/session.ts
@@ -91,6 +91,7 @@ function mapSessionInterstitials(
       typeof time === "string"
         ? DateTime.fromISO(time)
         : startTime.plus({ seconds: time });
+
     return {
       dateTime,
       duration,

--- a/packages/stitcher/src/types.ts
+++ b/packages/stitcher/src/types.ts
@@ -17,6 +17,7 @@ export interface InterstitialAssetList {
 
 export interface Interstitial {
   dateTime: DateTime;
+  duration?: number;
   assets?: InterstitialAsset[];
   vast?: InterstitialVast;
   assetList?: InterstitialAssetList;


### PR DESCRIPTION
Added a new `duration` attribute (in seconds) to the interstitials object in order to allow limiting the duration of the interstitial by adding the `X-PLAYOUT-LIMIT` tag.